### PR TITLE
Remove textStyle from HttpLoader

### DIFF
--- a/lib/src/widgets/http_loader.dart
+++ b/lib/src/widgets/http_loader.dart
@@ -75,16 +75,12 @@ class HttpLoader extends StatefulWidget {
   /// A flag to either enable or disable jsonLd parsing
   final bool disableJsonLd;
 
-  /// The default text style which is used to display textual content
-  final TextStyle? textStyle;
-
   /// Constructs a new [HttpLoader] [Widget]
   const HttpLoader({
     Key? key,
     required this.builder,
     required this.errorBuilder,
     required this.uri,
-    this.textStyle,
     this.onProcessedHtml,
     this.onNavigation,
     this.onFetching,
@@ -122,11 +118,8 @@ class _HttpLoaderState extends State<HttpLoader> {
       _fetchResult(oldWidget.uri);
     }
 
-    if (widget.textStyle != oldWidget.textStyle) {
-      final existingChild = builtChildren[widget.uri];
-
-      child = widget.builder(context, existingChild?.processedHtmlResult);
-    }
+    final existingChild = builtChildren[widget.uri];
+    child = widget.builder(context, existingChild?.processedHtmlResult);
 
     super.didUpdateWidget(oldWidget);
   }

--- a/lib/src/widgets/reader_mode.dart
+++ b/lib/src/widgets/reader_mode.dart
@@ -146,7 +146,6 @@ class _ReaderModeState extends State<ReaderMode> {
     return HttpLoader(
       method: widget.method,
       userAgent: widget.userAgent,
-      textStyle: widget.textStyle,
       onProcessedHtml: _onProcessedHtml,
       onNavigation: _onNavigation,
       onFetching: _onFetching,


### PR DESCRIPTION
Fix an issue where saved `TextStyle` in `HttpLoader` was preventing theme updates even though the `TextStyle` in `ReaderMode` was updated.